### PR TITLE
Update main field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "activationEvents": [
     "*"
   ],
-  "main": "./extensions/material.theme.config",
+  "main": "./extensions/material.theme.config.js",
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
Without the .js on the file name the Material Theme: Settings command doesn't work for me.