### PR TITLE
fix: Add mix.lock icon

### DIFF
--- a/src/icons/partials/fileNames.js
+++ b/src/icons/partials/fileNames.js
@@ -125,5 +125,6 @@
   ".angular-cli.json": "_file_angular",
   "directive.ts": "_file_angular-directive",
   "directive.js": "_file_angular-directive",
-  "favicon.ico": "_file_favicon"
+  "favicon.ico": "_file_favicon",
+  "mix.lock": "_file_ex"
 },


### PR DESCRIPTION
Mix is Elixir’s build tool. `mix.lock` is how you lock dependencies.

<img width="95" alt="mix-lock-icon" src="https://user-images.githubusercontent.com/4433966/48326817-63d17180-e676-11e8-9d70-ae40cc95fefe.png">

 It’s incredibly jarring to see a Ruby icon in a sea of Elixir files.

A new Elixir icon with a little lock (as seen on `yarn.lock`) would be ideal. This pull request merely makes `mix.lock` use the Elixir icon.