### PR TITLE
Fix HTML attribute color for derivatives

### DIFF
--- a/src/themes/theme-template-color-theme.json
+++ b/src/themes/theme-template-color-theme.json
@@ -296,18 +296,8 @@
         "entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "{{variant.scheme.base.purple}}"
-      }
-    },
-    {
-      "name": "HTML Attributes",
-      "scope": [
-        "text.html.basic entity.other.attribute-name.html",
-        "text.html.basic entity.other.attribute-name"
-      ],
-      "settings": {
         "fontStyle": "italic",
-        "foreground": "{{variant.scheme.base.yellow}}"
+        "foreground": "{{variant.scheme.base.purple}}"
       }
     },
     {


### PR DESCRIPTION
VS Code now scopes HTML files as `text.html.derivative` instead of `text.html.basic` (see https://github.com/Microsoft/vscode/commit/cfc2a2212de9ea10943af58ebd1817a5ad196463).

So all HTML attributes are incorrectly rendered as purple instead of yellow.

![1](https://user-images.githubusercontent.com/4433966/50886854-8bea1080-142c-11e9-9288-42d54a0e688e.png)

Reducing the scope to `text.html` has the extra benefit of supporting embedded templates such as `text.html.ruby` and `text.html.elixir`.